### PR TITLE
Add Node.js tests for issue command

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "NODE_ENV=test node --loader ts-node/esm --test"
   },
   "keywords": [],
   "author": "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,21 @@
-// index.js
-import { Client, GatewayIntentBits, Events, MessageFlags } from 'discord.js';
+import { Client, GatewayIntentBits, Events, MessageFlags, Interaction } from 'discord.js';
 import axios from 'axios';
 import 'dotenv/config';
 
-const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+export const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 client.once(Events.ClientReady, () =>
   console.log(`🤖 Eingeloggt als ${client.user!.tag}`)
 );
 
-client.on(Events.InteractionCreate, async interaction => {
+export async function handleIssueInteraction(interaction: Interaction) {
   if (!interaction.isChatInputCommand()) return;
   if (interaction.commandName !== 'issue') return;
 
   const title = interaction.options.getString('titel');
-  const body  = interaction.options.getString('beschreibung')!
+  const body  = interaction.options.getString('beschreibung')!;
 
-  await interaction.deferReply({ flags: MessageFlags.Ephemeral }); // bis zu 15 Minuten Zeit
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
   try {
     const { data } = await axios.post(
@@ -43,6 +42,10 @@ client.on(Events.InteractionCreate, async interaction => {
       '❌ Fehler beim Erstellen des Issues. Wende dich direkt an Jonas.'
     );
   }
-});
+}
 
-client.login(process.env.DISCORD_TOKEN);
+client.on(Events.InteractionCreate, handleIssueInteraction);
+
+if (process.env.NODE_ENV !== 'test') {
+  client.login(process.env.DISCORD_TOKEN);
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,75 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+process.env.NODE_ENV = 'test';
+import { handleIssueInteraction } from '../src/index.ts';
+import axios from 'axios';
+
+function createInteraction({ title = 'T', body = 'B' } = {}) {
+  const replies = { deferred: false, message: null };
+  return {
+    isChatInputCommand: () => true,
+    commandName: 'issue',
+    options: {
+      getString(name) {
+        if (name === 'titel') return title;
+        if (name === 'beschreibung') return body;
+        return null;
+      },
+    },
+    user: { tag: 'User#1', id: '1' },
+    deferReply: async ({ flags }) => { replies.deferred = flags === 64; },
+    editReply: async msg => { replies.message = msg; },
+    _replies: replies,
+  };
+}
+
+test('skips if not chat input command', async () => {
+  const interaction = createInteraction();
+  interaction.isChatInputCommand = () => false;
+  let called = false;
+  const orig = axios.post;
+  axios.post = async () => { called = true; };
+  await handleIssueInteraction(interaction);
+  axios.post = orig;
+  assert.equal(called, false);
+  assert.equal(interaction._replies.deferred, false);
+});
+
+test('skips if command name differs', async () => {
+  const interaction = createInteraction();
+  interaction.commandName = 'other';
+  let called = false;
+  const orig = axios.post;
+  axios.post = async () => { called = true; };
+  await handleIssueInteraction(interaction);
+  axios.post = orig;
+  assert.equal(called, false);
+  assert.equal(interaction._replies.deferred, false);
+});
+
+test('creates issue and replies with url', async () => {
+  const interaction = createInteraction({ title: 'hi', body: 'desc' });
+  process.env.GITHUB_REPO = 'a/b';
+  process.env.GITHUB_TOKEN = 't';
+  let received;
+  const orig = axios.post;
+  axios.post = async (url, payload) => {
+    received = { url, payload };
+    return { data: { html_url: 'https://example.com/1' } };
+  };
+  await handleIssueInteraction(interaction);
+  axios.post = orig;
+  assert.equal(interaction._replies.deferred, true);
+  assert.equal(interaction._replies.message, '✅ Issue erstellt: <https://example.com/1>');
+  assert.ok(received.url.includes('a/b/issues'));
+  assert.equal(received.payload.title, 'hi');
+});
+
+test('handles axios error', async () => {
+  const interaction = createInteraction();
+  const orig = axios.post;
+  axios.post = async () => { throw new Error('fail'); };
+  await handleIssueInteraction(interaction);
+  axios.post = orig;
+  assert.equal(interaction._replies.message, '❌ Fehler beim Erstellen des Issues. Wende dich direkt an Jonas.');
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "libReplacement": true,                           /* Enable lib replacement. */
@@ -26,7 +26,8 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "nodenext",                                /* Specify what module code is generated. */
+    "moduleResolution": "nodenext",                      /* Use Node's ESM resolution logic. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */


### PR DESCRIPTION
## Summary
- export interaction handler from `index.ts` so it can be tested
- compile to NodeNext ESM when using TypeScript
- add basic tests for the issue command using the built-in `node:test`
- run tests with `ts-node` loader

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68726ba904848331ab96126d9a28aa8f