### PR TITLE
Add tests for deploy-commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npx tsc src/deploy-commands.ts --module es2020 --target es2020 --moduleResolution node --esModuleInterop --skipLibCheck --outDir dist && node --test"
   },
   "keywords": [],
   "author": "",

--- a/src/deploy-commands.ts
+++ b/src/deploy-commands.ts
@@ -1,8 +1,9 @@
 // deploy-commands.js
 import { REST, Routes, SlashCommandBuilder } from 'discord.js';
+import { fileURLToPath } from 'url';
 import 'dotenv/config';
 
-const commands = [
+export const commands = [
   new SlashCommandBuilder()
     .setName('issue')
     .setDescription('Erstellt ein GitHub Issue')
@@ -17,17 +18,22 @@ const commands = [
     .toJSON(),
 ];
 
-const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN!);
+export async function deployCommands(rest: REST, applicationId: string): Promise<void> {
+  await rest.put(
+    Routes.applicationCommands(applicationId),
+    { body: commands },
+  );
+}
 
-(async () => {
-  try {
-    console.log('❯ Registriere Slash-Commands …');
-    await rest.put(
-      Routes.applicationCommands(process.env.APPLICATION_ID!),
-      { body: commands },
-    );
-    console.log('✓ Slash-Commands global registriert (kann bis zu 1 h dauern).');
-  } catch (err) {
-    console.error(err);
-  }
-})();
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN!);
+  (async () => {
+    try {
+      console.log('❯ Registriere Slash-Commands …');
+      await deployCommands(rest, process.env.APPLICATION_ID!);
+      console.log('✓ Slash-Commands global registriert (kann bis zu 1 h dauern).');
+    } catch (err) {
+      console.error(err);
+    }
+  })();
+}

--- a/test/deploy-commands.test.js
+++ b/test/deploy-commands.test.js
@@ -1,0 +1,27 @@
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { commands, deployCommands } = require('../dist/deploy-commands.js');
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Routes } from 'discord.js';
+
+test('commands array contains issue command', () => {
+  assert.ok(Array.isArray(commands));
+  assert.equal(commands.length, 1);
+  const cmd = commands[0];
+  assert.equal(cmd.name, 'issue');
+  assert.equal(cmd.description, 'Erstellt ein GitHub Issue');
+  const titelOption = cmd.options.find(o => o.name === 'titel');
+  assert.ok(titelOption);
+  assert.equal(titelOption.type, 3);
+});
+
+test('deployCommands posts commands', async () => {
+  const calls = [];
+  const mockRest = { put: async (...args) => { calls.push(args); } };
+  await deployCommands(mockRest, '123');
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0][0], Routes.applicationCommands('123'));
+  assert.deepEqual(calls[0][1], { body: commands });
+});


### PR DESCRIPTION
## Summary
- add exports and execution guard to `deploy-commands.ts`
- compile deploy script before running tests
- add tests verifying command definition and deployment logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68726b9dede08331bbf0544b0963be0c