### PR TITLE
Switch to Jest for TypeScript support

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,11 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts', '.js'],
+  testMatch: ['**/test/**/*.test.js'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_ENV=test node --loader ts-node/esm --test test/*.test.js"
+    "test": "NODE_ENV=test jest"
   },
   "keywords": [],
   "author": "",
@@ -18,6 +18,9 @@
   "devDependencies": {
     "@types/node": "^24.0.13",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.3"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,8 +1,8 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-process.env.NODE_ENV = 'test';
-import { handleIssueInteraction } from '../src/index.ts';
+import { jest } from '@jest/globals';
 import axios from 'axios';
+import { handleIssueInteraction } from '../src/index.ts';
+
+process.env.NODE_ENV = 'test';
 
 function createInteraction({ title = 'T', body = 'B' } = {}) {
   const replies = { deferred: false, message: null };
@@ -23,53 +23,45 @@ function createInteraction({ title = 'T', body = 'B' } = {}) {
   };
 }
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 test('skips if not chat input command', async () => {
   const interaction = createInteraction();
   interaction.isChatInputCommand = () => false;
-  let called = false;
-  const orig = axios.post;
-  axios.post = async () => { called = true; };
+  const postSpy = jest.spyOn(axios, 'post').mockResolvedValue();
   await handleIssueInteraction(interaction);
-  axios.post = orig;
-  assert.equal(called, false);
-  assert.equal(interaction._replies.deferred, false);
+  expect(postSpy).not.toHaveBeenCalled();
+  expect(interaction._replies.deferred).toBe(false);
 });
 
 test('skips if command name differs', async () => {
   const interaction = createInteraction();
   interaction.commandName = 'other';
-  let called = false;
-  const orig = axios.post;
-  axios.post = async () => { called = true; };
+  const postSpy = jest.spyOn(axios, 'post').mockResolvedValue();
   await handleIssueInteraction(interaction);
-  axios.post = orig;
-  assert.equal(called, false);
-  assert.equal(interaction._replies.deferred, false);
+  expect(postSpy).not.toHaveBeenCalled();
+  expect(interaction._replies.deferred).toBe(false);
 });
 
 test('creates issue and replies with url', async () => {
   const interaction = createInteraction({ title: 'hi', body: 'desc' });
   process.env.GITHUB_REPO = 'a/b';
   process.env.GITHUB_TOKEN = 't';
-  let received;
-  const orig = axios.post;
-  axios.post = async (url, payload) => {
-    received = { url, payload };
-    return { data: { html_url: 'https://example.com/1' } };
-  };
+  const postSpy = jest.spyOn(axios, 'post').mockResolvedValue({ data: { html_url: 'https://example.com/1' } });
   await handleIssueInteraction(interaction);
-  axios.post = orig;
-  assert.equal(interaction._replies.deferred, true);
-  assert.equal(interaction._replies.message, '✅ Issue erstellt: <https://example.com/1>');
-  assert.ok(received.url.includes('a/b/issues'));
-  assert.equal(received.payload.title, 'hi');
+  expect(interaction._replies.deferred).toBe(true);
+  expect(interaction._replies.message).toBe('✅ Issue erstellt: <https://example.com/1>');
+  expect(postSpy).toHaveBeenCalled();
+  const [url, payload] = postSpy.mock.calls[0];
+  expect(url).toContain('a/b/issues');
+  expect(payload.title).toBe('hi');
 });
 
 test('handles axios error', async () => {
   const interaction = createInteraction();
-  const orig = axios.post;
-  axios.post = async () => { throw new Error('fail'); };
+  jest.spyOn(axios, 'post').mockRejectedValue(new Error('fail'));
   await handleIssueInteraction(interaction);
-  axios.post = orig;
-  assert.equal(interaction._replies.message, '❌ Fehler beim Erstellen des Issues. Wende dich direkt an Jonas.');
+  expect(interaction._replies.message).toBe('❌ Fehler beim Erstellen des Issues. Wende dich direkt an Jonas.');
 });


### PR DESCRIPTION
## Summary
- configure Jest with ts-jest
- update package.json to use Jest
- rewrite tests using Jest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687291e67de48331942cc9aefbe48d56