### PR TITLE
Add message listener for error reports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,14 @@
-import { Client, GatewayIntentBits, Events, MessageFlags, Interaction } from 'discord.js';
+import { Client, GatewayIntentBits, Events, MessageFlags, Interaction, Message } from 'discord.js';
 import axios from 'axios';
 import 'dotenv/config';
 
-export const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+export const client = new Client({
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.MessageContent,
+  ],
+});
 
 client.once(Events.ClientReady, () =>
   console.log(`🤖 Eingeloggt als ${client.user!.tag}`)
@@ -44,7 +50,25 @@ export async function handleIssueInteraction(interaction: Interaction) {
   }
 }
 
+export async function handleMessageCreate(message: Message) {
+  if (message.author.bot) return;
+  const text = message.content.toLowerCase();
+  const keywords = [
+    'bug',
+    'fehler',
+    'funktioniert nicht',
+    'app stürzt ab',
+    'app stuerzt ab',
+  ];
+  if (keywords.some(k => text.includes(k))) {
+    await message.reply(
+      'Möchtest du daraus ein GitHub-Issue erstellen? Verwende dazu den /issue Befehl.'
+    );
+  }
+}
+
 client.on(Events.InteractionCreate, handleIssueInteraction);
+client.on(Events.MessageCreate, handleMessageCreate);
 
 if (process.env.NODE_ENV !== 'test') {
   client.login(process.env.DISCORD_TOKEN);


### PR DESCRIPTION
## Summary
- listen for `messageCreate` events and react to error keywords
- add tests for new listener
- update client intents for reading messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874c2cb7100833199a1db3e6ca7bfdc