### PR TITLE
Add TypeScript and security workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,18 @@
+name: Security Audit
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm audit --audit-level=high

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,18 @@
+name: TypeScript Check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_ENV=test node --loader ts-node/esm --test test/*.test.js"
+    "test": "NODE_ENV=test node --loader ts-node/esm --test test/*.test.js",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `typecheck` npm script
- run TypeScript build check on PRs and pushes
- run automated security audit weekly

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687761cdeb7c8331854b06e11aa9264a