### PR TITLE
Fix entry path and command spelling

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "description": "",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
     "test": "NODE_ENV=test node --test test/*.test.js",
     "typecheck": "tsc --noEmit -p jsconfig.json"

--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -11,7 +11,7 @@ export async function deployCommands({ REST, Routes, SlashCommandBuilder }, log 
             .setDescription('Erstelle einen aussagekräftigen Titel für das Issue')
             .setRequired(true))
             .addStringOption(opt => opt.setName('beschreibung')
-            .setDescription('Beschreibe das Problem oder Feature ausführlich, beschriebe Schritte zum Reproduzieren.')
+            .setDescription('Beschreibe das Problem oder Feature ausführlich, beschreibe Schritte zum Reproduzieren.')
             .setRequired(false))
             .toJSON(),
     ];

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export async function handleIssueInteraction(interaction) {
     if (interaction.commandName !== 'issue')
         return;
     const title = interaction.options.getString('titel');
-    const body = interaction.options.getString('beschreibung');
+    const body = interaction.options.getString('beschreibung') ?? '';
     await interaction.deferReply({ flags: MessageFlags.Ephemeral });
     try {
         const { data } = await axios.post(`https://api.github.com/repos/${process.env.GITHUB_REPO}/issues`, {


### PR DESCRIPTION
## Summary
- fix `main` entry in package.json
- fix typo in command description
- ensure empty body string when no description provided

## Testing
- `npm test`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6888adbc3e108331b1cbd218ed435bd4